### PR TITLE
Configure Spring Boot for local development environment

### DIFF
--- a/MAILDEV.md
+++ b/MAILDEV.md
@@ -1,0 +1,88 @@
+1. Ensure MailDev is Running
+   MailDev runs a local SMTP server on port `1025` and a web UI for viewing emails on port `1080`.
+    - **To start MailDev locally**:
+    - Run the following command:
+      ```bash
+      docker run -d -p 1025:1025 -p 1080:1080 maildev/maildev
+      ```
+    - **To access the MailDev web UI**:
+    - Open your browser and navigate to `http://localhost:1080`.
+    - You can view the emails sent by the application in the MailDev web UI.
+    - **To stop MailDev**:
+    - Run the following command:
+      ```bash
+      docker stop $(docker ps -q --filter ancestor=maildev/maildev)
+      ```
+2. on windows, you can use the following command to stop MailDev
+   ```bash
+   npm install -g maildev
+    ```
+3. Start MailDev: To start MailDev, use the following command in your terminal:
+   ```bash
+   maildev
+   ```
+4. Access the MailDev Web Interface: Once MailDev is running, you can access the web interface by navigating to
+   `http://localhost:1080` in your browser.
+5. Send Test Emails: You can send test emails from your application to the MailDev SMTP server. The emails will be
+   displayed in the MailDev web interface.
+6. Stop MailDev: To stop MailDev, press `Ctrl + C` in the terminal where MailDev is running.
+
+- **Configure the Application to Use MailDev**:
+  To configure the application to use MailDev, you need to set the SMTP server configuration in the application
+  properties.
+    - **For Spring Boot Applications**:
+        - Open the `application.properties` file in the `src/main/resources` directory.
+        - Add the following configuration:
+          ```properties
+          spring.mail.host=localhost
+          spring.mail.port=1025
+          spring.mail.properties.mail.smtp.auth=false
+          spring.mail.properties.mail.smtp.starttls.enable=false
+          ```
+        - Save the file.
+- **Send Emails from the Application**:
+    1. Once you’ve configured the application to use MailDev, you can send emails from the application.
+        - **For Spring Boot Applications**:
+            - Use the `JavaMailSender` interface to send emails.
+            - Inject the `JavaMailSender` bean into your service or controller.
+            - Use the `send()` method to send emails.
+            - Here's an example of sending an email using `JavaMailSender`:
+   ```java
+             import org.springframework.beans.factory.annotation.Autowired;
+
+         import org.springframework.mail.SimpleMailMessage;
+         import org.springframework.mail.javamail.JavaMailSender;
+         import org.springframework.web.bind.annotation.GetMapping;
+         import org.springframework.web.bind.annotation.RestController;
+      
+         @RestController
+         public class EmailTestController {
+      
+             @Autowired
+             private JavaMailSender emailSender;
+      
+             @GetMapping("/sendTestEmail")
+             public String sendTestEmail() {
+                 try {
+                     SimpleMailMessage message = new SimpleMailMessage();
+                     message.setTo("recipient@example.com");  // You can use your own email or a test email
+                     message.setSubject("Test Email");
+                     message.setText("This is a test email sent from Spring Boot.");
+                     emailSender.send(message);
+                     return "Test email sent successfully!";
+                 } catch (Exception e) {
+                     return "Error sending test email: " + e.getMessage();
+                 }
+             }
+      
+         }
+   ```
+- **By default, MailDev will run**:
+
+  SMTP server on port 1025
+  Web UI for viewing emails on port 1080
+
+- **Verify that MailDev is running**:
+
+  Access the MailDev web UI by navigating to http://localhost:1080 in your browser.
+  You should see the MailDev interface where emails are displayed.

--- a/book-network/src/main/resources/application-dev.yml
+++ b/book-network/src/main/resources/application-dev.yml
@@ -1,0 +1,42 @@
+# Set the active profile to 'dev' for development
+spring:
+  datasource:
+    driver-class-name: org.postgresql.Driver   # Set the driver class for PostgreSQL
+    url: jdbc:postgresql://localhost:5432/book_network_api  # Make sure this is correct and the DB exists
+    username: postgresql  # Set the username for the database
+    password: Janina1.    # Set the password for the database
+
+  jpa:
+    hibernate:
+      ddl-auto: none  # Set to 'none' to prevent automatic schema generation. You can change it to 'update' for dev environments
+    open-in-view: false  # Set too false to prevent lazy loading issues in views
+    show-sql: true  # Show SQL queries in the logs (optional)
+    properties:
+      hibernate:
+        temp:
+        use_jdbc_metadata_defaults: false
+      format_sql: true   # Format SQL queries in the logs (optional)
+    database: postgresql   # Set the database type to PostgreSQL
+    database-platform: org.hibernate.dialect.PostgreSQLDialect  # PostgreSQL's dialect for Hibernate
+
+  # Set the SQL initialization mode to 'never' to prevent Spring Boot from running schema initialization scripts at startup
+  sql:
+    init:
+      mode: never  # Prevent Spring Boot from running schema initialization scripts at startup (optional)
+
+  mail:
+    host: localhost
+    port: 1025
+    username: user  # You can leave this blank for FakeSMTP or MailHog
+    password: password  # Same for this
+    properties:
+      mail:
+        smtp:
+          trust: "*"
+          auth: false  # MailHog and FakeSMTP typically do not require authentication
+          starttls.enable: false  # Disable StartTLS for local SMTP servers like MailHog
+          connectiontimeout: 5000
+          timeout: 3000
+          writetimeout: 5000
+
+

--- a/book-network/src/main/resources/application-test.yml
+++ b/book-network/src/main/resources/application-test.yml
@@ -1,5 +1,4 @@
 spring:
-
   datasource:
     driver-class-name: org.postgresql.Driver
     url: jdbc:postgresql://localhost:5432/book_network_api  # Make sure this is correct and the DB exists
@@ -8,27 +7,33 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: none  # Set to 'none' to prevent automatic schema generation. You can change it to 'update' for dev environments
+      ddl-auto: update  # Set to 'none' to prevent automatic schema generation. You can change it to 'update' for dev
     open-in-view: false  # Set too false to prevent lazy loading issues in views
     show-sql: true  # Show SQL queries in the logs (optional)
-    show-format: true  # Format the SQL for better readability
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect  # PostgreSQL's dialect for Hibernate
+        dialect: org.hibernate.dialect.PostgreSQLDialect  # PostgreSQLs dialect for Hibernate
         temp:
           use_jdbc_metadata_defaults: false
+        format_sql: true
+    database: postgresql
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+  mail:
+    host: localhost
+    port: 1025
+    username: user  # You can leave this blank for FakeSMTP or MailHog
+    password: password  # Same for this
+    properties:
+      mail:
+        smtp:
+          trust: "*"
+          auth: false  # MailHog and FakeSMTP typically do not require authentication
+          starttls.enable: false  # Disable StartTLS for local SMTP servers like MailHog
+          connectiontimeout: 5000
+          timeout: 3000
+          writetimeout: 5000
 
   sql:
     init:
       mode: always
-
-  security:
-    user:
-      name: vani
-      password: 123
-
-management:
-  endpoints:
-    web:
-      exposure:
-        include: beans,loggers,metrics,health,info,readiness

--- a/book-network/src/main/resources/application.yml
+++ b/book-network/src/main/resources/application.yml
@@ -1,28 +1,17 @@
 server:
-  port: 8081
+  servlet:
+    context-path: /api/v1  # Base path for all API endpoints
+  port: 8088
 
 spring:
-  datasource:
-    driver-class-name: org.postgresql.Driver
-    url: jdbc:postgresql://localhost:5432/book_network_api  # Make sure this is correct and the DB exists
-    username: postgresql
-    password: Janina1.
+  profiles:
+    active: dev,test
+  servlet:
+    multipart:
+      max-file-size: 50MB  # Maximum file size for file uploads (optional)
 
-  jpa:
-    hibernate:
-      ddl-auto: none  # Set to 'none' to prevent automatic schema generation. You can change it to 'update' for dev environments
-    open-in-view: false  # Set too false to prevent lazy loading issues in views
-    show-sql: true  # Show SQL queries in the logs (optional)
-    show-format: true  # Format the SQL for better readability
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.PostgreSQLDialect  # PostgreSQL's dialect for Hibernate
-        temp:
-          use_jdbc_metadata_defaults: false
-
-  sql:
-    init:
-      mode: never  # Prevent Spring Boot from running schema initialization scripts at startup (optional)
+springdoc:
+  default-produces-media-type: application/json  # Default media type for Swagger API responses
 
   security:
     user:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: root
-      POSTGRES_DB: boot_social_network
+      POSTGRES_DB: book_network_api
       PGDATA: /var/lib/postgresql/data
     volumes:
       - postgres:/var/lib/postgresql/data
@@ -47,7 +47,7 @@ services:
     environment:
 
       - SPRING_PROFILES_ACTIVE: docker #active spring profile
-      - SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/boot_social_network
+      - SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/book_network_api
       - SPRING_DATASOURCE_USERNAME: root
       - SPRING_DATASOURCE_PASSWORD: root
       - SPRING_JPA_HIBERNATE_DDL_AUTO: none


### PR DESCRIPTION
- Set up MailDev integration for email testing (SMTP on localhost:1025)
- Updated `application.yml` to configure SMTP settings for MailDev
- Configured database connection for development and test environments (PostgreSQL)
- Added profile-based configuration for different environments (dev, test)
- Adjusted JPA properties for PostgreSQL and Hibernate settings
- Enabled SQL logging and disabled schema auto-generation in dev profile
- Prevented schema initialization at startup in dev and test environments